### PR TITLE
Enhance tower visuals and upgrades

### DIFF
--- a/src/components/TowerSpot.tsx
+++ b/src/components/TowerSpot.tsx
@@ -15,7 +15,10 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
   const unlockSlot = useGameStore((s) => s.unlockSlot);
 
   const canBuild = slot.unlocked && !slot.tower && gold >= GAME_CONSTANTS.TOWER_COST;
-  const canUpgrade = slot.tower && slot.tower.level < GAME_CONSTANTS.TOWER_MAX_LEVEL && gold >= GAME_CONSTANTS.TOWER_UPGRADE_COST;
+  const canUpgrade =
+    slot.tower &&
+    slot.tower.level < GAME_CONSTANTS.TOWER_MAX_LEVEL &&
+    gold >= GAME_CONSTANTS.TOWER_UPGRADE_COST;
   const canUnlock = !slot.unlocked && gold >= (GAME_CONSTANTS.TOWER_SLOT_UNLOCK_GOLD[slotIdx] || 0);
 
   // Health bar for tower
@@ -48,8 +51,8 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
           cx={slot.x}
           cy={slot.y}
           r={GAME_CONSTANTS.TOWER_SIZE / 2}
-          fill="#888"
-          stroke="#333"
+          fill={canUnlock ? '#ff6666' : '#661515'}
+          stroke="#330000"
           strokeWidth={4}
           style={{ cursor: canUnlock ? 'pointer' : 'not-allowed' }}
           onClick={() => canUnlock && unlockSlot(slotIdx)}
@@ -59,8 +62,8 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
           cx={slot.x}
           cy={slot.y}
           r={GAME_CONSTANTS.TOWER_SIZE / 2}
-          fill={canBuild ? '#00cfff' : '#bbb'}
-          stroke="#0077ff"
+          fill={canBuild ? '#4ade80' : '#444'}
+          stroke="#166534"
           strokeWidth={4}
           style={{ cursor: canBuild ? 'pointer' : 'not-allowed' }}
           onClick={() => canBuild && buildTower(slotIdx)}
@@ -81,6 +84,14 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
           {/* Health bar */}
           {healthBar}
           {healthFill}
+          {canUpgrade && (
+            <polygon
+              points={`${slot.x},${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 24} ${slot.x - GAME_CONSTANTS.UPGRADE_ARROW_SIZE / 2},${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 10} ${slot.x + GAME_CONSTANTS.UPGRADE_ARROW_SIZE / 2},${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 10}`}
+              fill={GAME_CONSTANTS.UPGRADE_ARROW_COLOR}
+              style={{ cursor: 'pointer' }}
+              onClick={() => upgradeTower(slotIdx)}
+            />
+          )}
         </g>
       )}
     </g>

--- a/src/logic/EnemySpawner.ts
+++ b/src/logic/EnemySpawner.ts
@@ -58,7 +58,8 @@ export function startEnemyWave() {
 }
 
 export function updateEnemyMovement() {
-  const { enemies, towerSlots, damageTower, removeEnemy } = useGameStore.getState();
+  const { enemies, towerSlots, damageTower, removeEnemy, addGold } =
+    useGameStore.getState();
   enemies.forEach((enemy) => {
     const targetSlot = getNearestSlot(enemy.position);
     if (!targetSlot) return;
@@ -68,9 +69,12 @@ export function updateEnemyMovement() {
     if (dist < (enemy.size + GAME_CONSTANTS.TOWER_SIZE) / 2) {
       // Damage tower if present
       if (targetSlot.tower) {
-        const slotIdx = towerSlots.findIndex(s => s.x === targetSlot.x && s.y === targetSlot.y);
+        const slotIdx = towerSlots.findIndex(
+          (s) => s.x === targetSlot.x && s.y === targetSlot.y,
+        );
         damageTower(slotIdx, 10);
       }
+      addGold(enemy.goldValue);
       removeEnemy(enemy.id);
       return;
     }

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,6 +1,6 @@
 export const GAME_CONSTANTS = {
   // Canvas
-  CANVAS_BG: '#f0f0f0',
+  CANVAS_BG: '#1e1e2f',
   CANVAS_WIDTH: 1920,
   CANVAS_HEIGHT: 1080,
 
@@ -16,8 +16,10 @@ export const GAME_CONSTANTS = {
   TOWER_COST: 100,
   TOWER_UPGRADE_COST: 120,
   TOWER_MAX_LEVEL: 3,
-  TOWER_COLORS: ['#0077ff', '#00cfff', '#00ff99'],
+  TOWER_COLORS: ['#3b82f6', '#9333ea', '#f97316'],
   TOWER_HEALTHBAR_HEIGHT: 8,
+  UPGRADE_ARROW_SIZE: 14,
+  UPGRADE_ARROW_COLOR: '#4ade80',
 
   // Tower Upgrades
   TOWER_UPGRADES: [
@@ -49,7 +51,7 @@ export const GAME_CONSTANTS = {
   // Bullet
   BULLET_SIZE: 10,
   BULLET_SPEED: 420,
-  BULLET_COLOR: '#ffe600',
+  BULLET_COLOR: '#f43f5e',
 
   // UI
   GOLD_COLOR: '#FFD700',


### PR DESCRIPTION
## Summary
- re-theme game with dark canvas, new tower colors and bullet style
- show placement slots in green or red based on availability
- add upgrade arrow indicator and new constants
- award gold when enemies collide with towers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685074818620832caa80f2de9f946825