### PR TITLE
Add simple fire effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A hybrid shooter and tower defense game built with React, TypeScript, and Canvas
 - Weapon upgrade system
 - Gold economy
 - Tower placement and upgrades
+- Towers can be destroyed and rebuilt
+- Bullet hits trigger a fire effect
 
 ## Technologies Used
 

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -10,6 +10,7 @@ export const GameBoard: React.FC = () => {
     towerSlots,
     enemies,
     bullets,
+    effects,
     gold,
     currentWave,
     isStarted,
@@ -124,6 +125,18 @@ export const GameBoard: React.FC = () => {
             fill={bullet.color}
             stroke="#b3b300"
             strokeWidth={2}
+          />
+        ))}
+        {/* Effects */}
+        {effects.map((effect) => (
+          <circle
+            key={effect.id}
+            cx={effect.position.x}
+            cy={effect.position.y}
+            r={(effect.radius * effect.life) / effect.maxLife}
+            fill={effect.color}
+            fillOpacity={effect.life / effect.maxLife}
+            stroke="none"
           />
         ))}
       </svg>

--- a/src/logic/Effects.ts
+++ b/src/logic/Effects.ts
@@ -1,0 +1,12 @@
+import { useGameStore } from '../models/store';
+import { GAME_CONSTANTS } from '../utils/Constants';
+
+export function updateEffects() {
+  const { effects, removeEffect } = useGameStore.getState();
+  effects.forEach((effect) => {
+    effect.life -= GAME_CONSTANTS.GAME_TICK;
+    if (effect.life <= 0) {
+      removeEffect(effect.id);
+    }
+  });
+}

--- a/src/logic/GameLoop.ts
+++ b/src/logic/GameLoop.ts
@@ -1,5 +1,6 @@
 import { updateTowerFire, updateBullets } from './TowerManager';
 import { updateEnemyMovement } from './EnemySpawner';
+import { updateEffects } from './Effects';
 import { GAME_CONSTANTS } from '../utils/Constants';
 
 export function startGameLoop() {
@@ -7,6 +8,7 @@ export function startGameLoop() {
     updateEnemyMovement();
     updateTowerFire();
     updateBullets();
+    updateEffects();
   }, GAME_CONSTANTS.GAME_TICK);
   return () => clearInterval(interval);
 }

--- a/src/logic/TowerManager.ts
+++ b/src/logic/TowerManager.ts
@@ -1,5 +1,6 @@
 import { useGameStore } from '../models/store';
 import { GAME_CONSTANTS } from '../utils/Constants';
+import type { Effect } from '../models/gameTypes';
 import type { Enemy, Position } from '../models/gameTypes';
 
 function getDirection(from: Position, to: Position) {
@@ -67,6 +68,7 @@ export function updateBullets() {
     removeBullet,
     enemies,
     damageEnemy,
+    addEffect,
   } = useGameStore.getState();
   bullets.forEach((b) => {
     b.position.x += b.direction.x * b.speed * 0.016;
@@ -88,6 +90,15 @@ export function updateBullets() {
       const dist = Math.sqrt(dx * dx + dy * dy);
       if (dist < (e.size + b.size) / 2) {
         damageEnemy(e.id, b.damage);
+        const effect: Effect = {
+          id: `${Date.now()}-${Math.random()}`,
+          position: { x: b.position.x, y: b.position.y },
+          radius: 20,
+          color: '#ff6600',
+          life: 300,
+          maxLife: 300,
+        };
+        addEffect(effect);
         removeBullet(b.id);
         break;
       }

--- a/src/models/gameTypes.ts
+++ b/src/models/gameTypes.ts
@@ -42,13 +42,23 @@ export interface Bullet {
   color: string;
 }
 
+export interface Effect {
+  id: string;
+  position: Position;
+  radius: number;
+  color: string;
+  life: number;
+  maxLife: number;
+}
+
 export interface GameState {
   towers: Tower[];
   towerSlots: TowerSlot[];
   enemies: Enemy[];
   bullets: Bullet[];
+  effects: Effect[];
   gold: number;
   currentWave: number;
   isGameOver: boolean;
   isStarted: boolean;
-} 
+}

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { GameState, Tower, TowerSlot, Enemy, Bullet, Position } from './gameTypes';
+import type { GameState, Tower, TowerSlot, Enemy, Bullet, Position, Effect } from './gameTypes';
 import { GAME_CONSTANTS } from '../utils/Constants';
 
 const initialSlots: TowerSlot[] = GAME_CONSTANTS.TOWER_SLOTS.map((slot, i) => ({
@@ -13,6 +13,7 @@ const initialState: GameState = {
   towerSlots: initialSlots,
   enemies: [],
   bullets: [],
+  effects: [],
   gold: 200,
   currentWave: 1,
   isGameOver: false,
@@ -32,6 +33,8 @@ type Store = GameState & {
   damageEnemy: (enemyId: string, dmg: number) => void;
   addBullet: (bullet: Bullet) => void;
   removeBullet: (bulletId: string) => void;
+  addEffect: (effect: Effect) => void;
+  removeEffect: (effectId: string) => void;
   nextWave: () => void;
   resetGame: () => void;
   setStarted: (started: boolean) => void;
@@ -152,6 +155,8 @@ export const useGameStore = create<Store>((set, get) => ({
 
   addBullet: (bullet) => set((state) => ({ bullets: [...state.bullets, bullet] })),
   removeBullet: (bulletId) => set((state) => ({ bullets: state.bullets.filter(b => b.id !== bulletId) })),
+  addEffect: (effect) => set((state) => ({ effects: [...state.effects, effect] })),
+  removeEffect: (effectId) => set((state) => ({ effects: state.effects.filter(e => e.id !== effectId) })),
 
   nextWave: () => set((state) => ({ currentWave: state.currentWave + 1 })),
   resetGame: () => set(() => ({ ...initialState, towerSlots: initialSlots })),

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,6 +1,6 @@
 export const GAME_CONSTANTS = {
   // Canvas
-  CANVAS_BG: '#1e1e2f',
+  CANVAS_BG: '#c7b98a',
   CANVAS_WIDTH: 1920,
   CANVAS_HEIGHT: 1080,
 


### PR DESCRIPTION
## Summary
- tweak canvas background color
- add effect objects to game state for hit animations
- render fading fire circles when bullets impact enemies
- update game loop to update effect lifetimes
- document rebuildable towers and fire effects

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_685075ac0da4832c86ee671b59a59f54