### PR TITLE
Add tower spot guidance text

### DIFF
--- a/src/components/TowerSpot.tsx
+++ b/src/components/TowerSpot.tsx
@@ -58,16 +58,38 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
           onClick={() => canUnlock && unlockSlot(slotIdx)}
         />
       ) : !slot.tower ? (
-        <circle
-          cx={slot.x}
-          cy={slot.y}
-          r={GAME_CONSTANTS.TOWER_SIZE / 2}
-          fill={canBuild ? '#4ade80' : '#444'}
-          stroke="#166534"
-          strokeWidth={4}
-          style={{ cursor: canBuild ? 'pointer' : 'not-allowed' }}
-          onClick={() => canBuild && buildTower(slotIdx)}
-        />
+        <g>
+          <circle
+            cx={slot.x}
+            cy={slot.y}
+            r={GAME_CONSTANTS.TOWER_SIZE / 2}
+            fill={canBuild ? '#4ade80' : '#444'}
+            stroke="#166534"
+            strokeWidth={4}
+            style={{ cursor: canBuild ? 'pointer' : 'not-allowed' }}
+            onClick={() => canBuild && buildTower(slotIdx)}
+          />
+          <text
+            x={slot.x}
+            y={slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 30}
+            fill="#ffffff"
+            fontSize={14}
+            fontWeight="bold"
+            textAnchor="middle"
+            pointerEvents="none"
+          >
+            {slot.wasDestroyed ? 'Kuleniz yıkıldı' : 'Kule inşa et'}
+          </text>
+          <polygon
+            points={`${slot.x},${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 24} ${
+              slot.x - 6
+            },${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 14} ${
+              slot.x + 6
+            },${slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 14}`}
+            fill="#ffffff"
+            pointerEvents="none"
+          />
+        </g>
       ) : (
         <g>
           <circle

--- a/src/models/gameTypes.ts
+++ b/src/models/gameTypes.ts
@@ -18,6 +18,8 @@ export interface TowerSlot {
   y: number;
   unlocked: boolean;
   tower?: Tower;
+  /** Indicates that a tower existed here and was destroyed */
+  wasDestroyed?: boolean;
 }
 
 export interface Enemy {

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -6,6 +6,7 @@ const initialSlots: TowerSlot[] = GAME_CONSTANTS.TOWER_SLOTS.map((slot, i) => ({
   ...slot,
   unlocked: i === 0, // Only first slot unlocked at start
   tower: undefined,
+  wasDestroyed: false,
 }));
 
 const initialState: GameState = {
@@ -59,7 +60,7 @@ export const useGameStore = create<Store>((set, get) => ({
       health: GAME_CONSTANTS.TOWER_HEALTH,
     };
     const newSlots = [...state.towerSlots];
-    newSlots[slotIdx] = { ...slot, tower: newTower };
+    newSlots[slotIdx] = { ...slot, tower: newTower, wasDestroyed: false };
     return {
       towers: [...state.towers, newTower],
       towerSlots: newSlots,
@@ -93,7 +94,7 @@ export const useGameStore = create<Store>((set, get) => ({
     const newHealth = slot.tower.health - dmg;
     if (newHealth <= 0) {
       const newSlots = [...state.towerSlots];
-      newSlots[slotIdx] = { ...slot, tower: undefined };
+      newSlots[slotIdx] = { ...slot, tower: undefined, wasDestroyed: true };
       return {
         towers: state.towers.filter(t => t.id !== slot.tower!.id),
         towerSlots: newSlots,
@@ -113,7 +114,7 @@ export const useGameStore = create<Store>((set, get) => ({
     const slot = state.towerSlots[slotIdx];
     if (!slot.tower) return {};
     const newSlots = [...state.towerSlots];
-    newSlots[slotIdx] = { ...slot, tower: undefined };
+    newSlots[slotIdx] = { ...slot, tower: undefined, wasDestroyed: false };
     return {
       towers: state.towers.filter(t => t.id !== slot.tower!.id),
       towerSlots: newSlots,
@@ -125,7 +126,7 @@ export const useGameStore = create<Store>((set, get) => ({
     const unlockCost = GAME_CONSTANTS.TOWER_SLOT_UNLOCK_GOLD[slotIdx] || 0;
     if (state.gold < unlockCost) return {};
     const newSlots = [...state.towerSlots];
-    newSlots[slotIdx] = { ...state.towerSlots[slotIdx], unlocked: true };
+    newSlots[slotIdx] = { ...state.towerSlots[slotIdx], unlocked: true, wasDestroyed: false };
     return {
       towerSlots: newSlots,
       gold: state.gold - unlockCost,


### PR DESCRIPTION
## Summary
- highlight empty tower slots with text and arrow
- track whether a slot's tower was destroyed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6852572ac824832cbf23c3478d29c9c4