### PR TITLE
Implement tower limits and shield upgrades

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -20,6 +20,7 @@ export const GameBoard: React.FC = () => {
     resetGame,
     nextWave,
     upgradeBullet,
+    purchaseShield,
     refreshBattlefield,
   } = useGameStore();
 
@@ -134,6 +135,16 @@ export const GameBoard: React.FC = () => {
           >
             {`Yeni Ateş: ${GAME_CONSTANTS.BULLET_TYPES[bulletLevel]?.name || ''}`} ({GAME_CONSTANTS.BULLET_UPGRADE_COST})
           </button>
+          {GAME_CONSTANTS.WALL_SHIELDS.map((s, i) => (
+            <button
+              key={i}
+              onClick={() => purchaseShield(i)}
+              disabled={gold < s.cost}
+              style={{ marginBottom: 8, padding: '8px 16px', fontSize: 20, borderRadius: 8, background: '#ffa500', color: '#000', border: 'none', cursor: 'pointer' }}
+            >
+              {`${s.name} (+${s.strength}) (${s.cost})`}
+            </button>
+          ))}
           <button
             onClick={() => {
               setRefreshing(false);

--- a/src/components/TowerSpot.tsx
+++ b/src/components/TowerSpot.tsx
@@ -12,16 +12,13 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
   const gold = useGameStore((s) => s.gold);
   const buildTower = useGameStore((s) => s.buildTower);
   const upgradeTower = useGameStore((s) => s.upgradeTower);
-  const unlockSlot = useGameStore((s) => s.unlockSlot);
   const buyWall = useGameStore((s) => s.buyWall);
-
-  const canBuild = slot.unlocked && !slot.tower && gold >= GAME_CONSTANTS.TOWER_COST;
+  const canBuild = !slot.tower && gold >= GAME_CONSTANTS.TOWER_COST;
   const canUpgrade =
     slot.tower &&
     slot.tower.level < GAME_CONSTANTS.TOWER_MAX_LEVEL &&
     gold >= GAME_CONSTANTS.TOWER_UPGRADE_COST;
-  const canUnlock = !slot.unlocked && gold >= (GAME_CONSTANTS.TOWER_SLOT_UNLOCK_GOLD[slotIdx] || 0);
-  const canBuyWall = slot.tower && slot.tower.wallStrength <= 0 && gold >= GAME_CONSTANTS.WALL_COST;
+  const canBuyWall = slot.tower && gold >= GAME_CONSTANTS.WALL_COST;
 
   // Health bar for tower
   const healthBar = slot.tower && (
@@ -48,31 +45,7 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({ slot, slotIdx }) => {
   return (
     <g>
       {/* Slot or Tower */}
-      {!slot.unlocked ? (
-        <g>
-          <circle
-            cx={slot.x}
-            cy={slot.y}
-            r={GAME_CONSTANTS.TOWER_SIZE / 2}
-            fill={canUnlock ? '#ff6666' : '#661515'}
-            stroke="#330000"
-            strokeWidth={4}
-            style={{ cursor: canUnlock ? 'pointer' : 'not-allowed' }}
-            onClick={() => canUnlock && unlockSlot(slotIdx)}
-          />
-          <text
-            x={slot.x}
-            y={slot.y - GAME_CONSTANTS.TOWER_SIZE / 2 - 30}
-            fill="#ffffff"
-            fontSize={14}
-            fontWeight="bold"
-            textAnchor="middle"
-            pointerEvents="none"
-          >
-            Kule inşa et
-          </text>
-        </g>
-      ) : !slot.tower ? (
+      {!slot.tower ? (
         <g>
           <circle
             cx={slot.x}

--- a/src/models/gameTypes.ts
+++ b/src/models/gameTypes.ts
@@ -66,6 +66,8 @@ export interface GameState {
   gold: number;
   bulletLevel: number;
   currentWave: number;
+  maxTowers: number;
+  globalWallStrength: number;
   isGameOver: boolean;
   isStarted: boolean;
 }

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -13,8 +13,8 @@ export const GAME_CONSTANTS = {
   TOWER_DAMAGE: 20,
   TOWER_FIRE_RATE: 800, // ms
   TOWER_HEALTH: 100,
-  TOWER_COST: 100,
-  TOWER_UPGRADE_COST: 120,
+  TOWER_COST: 50,
+  TOWER_UPGRADE_COST: 60,
   TOWER_MAX_LEVEL: 3,
   TOWER_COLORS: ['#00aaff', '#aa00ff', '#ffaa00'],
   TOWER_HEALTHBAR_HEIGHT: 8,
@@ -58,6 +58,7 @@ export const GAME_CONSTANTS = {
     3300,
   ],
   INITIAL_SLOT_COUNT: 2,
+  INITIAL_TOWER_LIMIT: 2,
 
   // Enemy
   ENEMY_SIZE: 36,
@@ -134,6 +135,18 @@ export const GAME_CONSTANTS = {
   ],
   BULLET_UPGRADE_COST: 300,
   WALL_COST: 150,
+  WALL_SHIELDS: [
+    { name: 'Taş Kalkanı', strength: 5, cost: 50 },
+    { name: 'Bronz Kalkanı', strength: 10, cost: 100 },
+    { name: 'Demir Kalkanı', strength: 15, cost: 150 },
+    { name: 'Çelik Kalkanı', strength: 20, cost: 200 },
+    { name: 'Mithril Kalkanı', strength: 25, cost: 250 },
+    { name: 'Adamantium Kalkanı', strength: 30, cost: 300 },
+    { name: 'Kristal Kalkanı', strength: 35, cost: 350 },
+    { name: 'Efsanevi Kalkan', strength: 40, cost: 400 },
+    { name: 'Gölge Kalkanı', strength: 45, cost: 450 },
+    { name: 'Işık Kalkanı', strength: 50, cost: 500 },
+  ],
 
   // UI
   GOLD_COLOR: '#FFD700',


### PR DESCRIPTION
## Summary
- make tower and upgrade costs cheaper
- add initial tower limit and shield upgrades in constants
- allow global wall strength and tower limits in game state
- implement build limits and shield purchase logic in store
- remove slot locking and simplify TowerSpot
- allow purchasing shields in refresh screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*
- `npm run build` *(fails: Cannot find module 'react' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68527248eb20832cb3ba8fc9d7d5e835