### PR TITLE
Improve randomness of tower placement and enemy movement

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -41,7 +41,7 @@ export const GameBoard: React.FC = () => {
   // Handle continue button click
   const handleContinue = () => {
     const slotCount = Math.min(
-      GAME_CONSTANTS.TOWER_SLOTS.length,
+      GAME_CONSTANTS.TOTAL_SLOT_COUNT,
       GAME_CONSTANTS.INITIAL_SLOT_COUNT + Math.floor(currentWave / 5)
     );
     refreshBattlefield(slotCount);

--- a/src/logic/EnemySpawner.ts
+++ b/src/logic/EnemySpawner.ts
@@ -55,7 +55,7 @@ function moveTowardsTarget(enemy: Enemy) {
   }
 
   // Normalize direction and apply speed (scaled for smoother movement)
-  const step = enemy.speed * 0.016; // approx 60 FPS
+  const step = enemy.speed * 0.5; // smoother movement
   enemy.position.x += (dx / distance) * step;
   enemy.position.y += (dy / distance) * step;
 }
@@ -174,7 +174,7 @@ export function updateEnemyMovement() {
       return;
     }
     // Move toward slot
-    const step = enemy.speed * 0.016;
+    const step = enemy.speed * 0.5;
     const moveX = (dx / dist) * step;
     const moveY = (dy / dist) * step;
     enemy.position.x += moveX;
@@ -187,8 +187,9 @@ export function updateEnemyMovement() {
   if (!this.isActive) return;
   
   // Update position based on path and speed
-  this.position.x += this.speed;
-  this.position.y += this.speed;
+  const step = this.speed * 0.5;
+  this.position.x += step;
+  this.position.y += step;
 
   // Check if enemy reached end of path
   if (this.position.x > GAME_CONSTANTS.CANVAS_WIDTH || 

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -1,15 +1,17 @@
 import { create } from 'zustand';
 import type { GameState, Tower, TowerSlot, Enemy, Bullet, Position, Effect } from './gameTypes';
-import { GAME_CONSTANTS } from '../utils/Constants';
+import { GAME_CONSTANTS, generateRandomTowerSlots } from '../utils/Constants';
 
-const initialSlots: TowerSlot[] = GAME_CONSTANTS.TOWER_SLOTS.slice(
-  0,
-  GAME_CONSTANTS.INITIAL_SLOT_COUNT,
-).map((slot) => ({
-  ...slot,
-  unlocked: true,
+const allSlots: TowerSlot[] = generateRandomTowerSlots(GAME_CONSTANTS.TOTAL_SLOT_COUNT).map(s => ({
+  ...s,
+  unlocked: false,
   tower: undefined,
   wasDestroyed: false,
+}));
+
+const initialSlots: TowerSlot[] = allSlots.slice(0, GAME_CONSTANTS.INITIAL_SLOT_COUNT).map(slot => ({
+  ...slot,
+  unlocked: true,
 }));
 
 const initialState: GameState = {
@@ -338,7 +340,7 @@ export const useGameStore = create<Store>((set, get) => ({
     };
   }),
   refreshBattlefield: (slots) => set((state) => {
-    const newSlots: TowerSlot[] = GAME_CONSTANTS.TOWER_SLOTS.slice(0, slots).map((s, i) => ({
+    const newSlots: TowerSlot[] = generateRandomTowerSlots(slots).map((s) => ({
       ...s,
       unlocked: true,
       tower: undefined,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -64,23 +64,7 @@ export const GAME_CONSTANTS = {
   ],
 
   // Tower Slots
-  TOWER_SLOTS: [
-    { x: 100, y: 100 },
-    { x: 200, y: 100 },
-    { x: 300, y: 100 },
-    { x: 400, y: 100 },
-    { x: 500, y: 100 },
-    { x: 100, y: 300 },
-    { x: 200, y: 300 },
-    { x: 300, y: 300 },
-    { x: 400, y: 300 },
-    { x: 500, y: 300 },
-    { x: 100, y: 500 },
-    { x: 200, y: 500 },
-    { x: 300, y: 500 },
-    { x: 400, y: 500 },
-    { x: 500, y: 500 }
-  ],
+  TOTAL_SLOT_COUNT: 15,
   TOWER_SLOT_UNLOCK_GOLD: [
     0,
     200,
@@ -389,4 +373,17 @@ export const GAME_CONSTANTS = {
   WAVE_DURATION: 30000,
   WAVE_ENEMY_INCREASE: 2,
   WAVE_ENEMY_HEALTH_INCREASE: 20,
-} as const; 
+} as const;
+
+export function generateRandomTowerSlots(count: number) {
+  const slots = [] as { x: number; y: number }[];
+  const cx = GAME_CONSTANTS.CANVAS_WIDTH / 2;
+  const cy = GAME_CONSTANTS.CANVAS_HEIGHT / 2;
+  const maxRadius = Math.min(cx, cy) * 0.7;
+  for (let i = 0; i < count; i++) {
+    const radius = maxRadius * (0.3 + Math.random() * 0.7);
+    const angle = Math.random() * Math.PI * 2;
+    slots.push({ x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) });
+  }
+  return slots;
+}


### PR DESCRIPTION
## Summary
- randomize tower slot placement at game start and between waves
- remove static `TOWER_SLOTS` list
- smooth enemy movement by increasing per-frame step

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6852cbf02dbc832cad0a5c9e9f78b9f3