### PR TITLE
Add MIT license and bilingual overview

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Shooter Tower Defense Game
 
-A hybrid shooter and tower defense game built with React, TypeScript, and Canvas API.
+A hybrid shooter and tower defense game built with React, TypeScript, and the Canvas API.
+
+## Overview (English)
+
+This game mixes fast-paced shooting with classic tower defense strategy. Build and upgrade towers while directly attacking waves of enemies. Earn gold from defeated foes to buy weapon upgrades and stronger defenses.
+
+## Genel Bakış (Türkçe)
+
+Bu oyun, hızlı tempolu nişancı mekaniğini geleneksel kule savunması ile birleştirir. Düşman dalgalarını püskürtmek için kuleler inşa edip yükseltirken aynı zamanda doğrudan ateş ederek savaşırsınız. Yenilen düşmanlardan elde edilen altın ile silah ve savunmalarınızı geliştirebilirsiniz.
 
 ## Features
 
@@ -62,4 +70,4 @@ The game is built using a component-based architecture with the following key sy
 
 ## License
 
-MIT 
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add MIT license file
- update README with English & Turkish overview
- point to license file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6852e064b890832caea8da6bb056e5d9