### PR TITLE
Fix lag with rAF-based game loop

### DIFF
--- a/src/logic/GameLoop.ts
+++ b/src/logic/GameLoop.ts
@@ -1,14 +1,24 @@
 import { updateTowerFire, updateBullets } from './TowerManager';
 import { updateEnemyMovement } from './EnemySpawner';
 import { updateEffects } from './Effects';
-import { GAME_CONSTANTS } from '../utils/Constants';
+import { useGameStore } from '../models/store';
 
 export function startGameLoop() {
-  const interval = window.setInterval(() => {
+  let frameId = 0;
+
+  const loop = () => {
     updateEnemyMovement();
     updateTowerFire();
     updateBullets();
     updateEffects();
-  }, GAME_CONSTANTS.GAME_TICK);
-  return () => clearInterval(interval);
+
+    // Force state update so React re-renders with new positions
+    useGameStore.setState({});
+
+    frameId = requestAnimationFrame(loop);
+  };
+
+  frameId = requestAnimationFrame(loop);
+
+  return () => cancelAnimationFrame(frameId);
 }


### PR DESCRIPTION
## Summary
- use `requestAnimationFrame` for the game loop
- trigger a store update each frame so React renders new positions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6853ba32e2248325ba5edc14e3ca1331