### PR TITLE
Fix energy warning overlay formatting

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -570,11 +570,21 @@ export const GameBoard: React.FC = () => {
         </div>
       </div>
 
-      {energyWarning && (
-        <div style={{ position: 'absolute', top: 80, left: 32, color: '#ff5555', font: GAME_CONSTANTS.UI_FONT, textShadow: GAME_CONSTANTS.UI_SHADOW, zIndex: 2 }}>
+      {energyWarning ? (
+        <div
+          style={{
+            position: 'absolute',
+            top: 80,
+            left: 32,
+            color: '#ff5555',
+            font: GAME_CONSTANTS.UI_FONT,
+            textShadow: GAME_CONSTANTS.UI_SHADOW,
+            zIndex: 2,
+          }}
+        >
           {energyWarning}
         </div>
-      )}
+      ) : null}
       {/* Debug message for tower relocation */}
       {debugMessage && (
         <div style={{ 
@@ -589,7 +599,7 @@ export const GameBoard: React.FC = () => {
           background: 'rgba(0,0,0,0.8)',
           padding: '12px 24px',
           borderRadius: '8px',
-          border: '2px solid #00cfff'
+          border: '2px solid #00cfff',
         }}>
           {debugMessage}
         </div>


### PR DESCRIPTION
## Summary
- refactor energy warning overlay to be conditional block
- add trailing comma for debug message styles

## Testing
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_b_68597970037c832cb524b68f2c4d64f3