### PR TITLE
Harden upgrade screen styles and events

### DIFF
--- a/src/ui/upgrade/ContinueButton.tsx
+++ b/src/ui/upgrade/ContinueButton.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useGameStore } from '../../models/store';
 import type { Store } from '../../models/store';
-import { footerStyles } from './Footer/footerStyles';
+import { footerStyles, getContinueButtonStyle } from './Footer/footerStyles';
 
 interface ContinueButtonProps {
   onContinueCallback?: () => void;
@@ -49,14 +49,14 @@ export const ContinueButton: React.FC<ContinueButtonProps> = ({ onContinueCallba
     }
   }, [nextWave, startPreparation, resetDice, setRefreshing, onContinueCallback]);
 
-  const handleMouseEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.currentTarget.style.transform = 'translateY(-2px)';
-    e.currentTarget.style.boxShadow = '0 8px 24px rgba(74, 222, 128, 0.6)';
+  const [hovered, setHovered] = useState(false);
+
+  const handleMouseEnter = () => {
+    setHovered(true);
   };
 
-  const handleMouseLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.currentTarget.style.transform = 'translateY(0)';
-    e.currentTarget.style.boxShadow = '0 6px 18px rgba(74, 222, 128, 0.4)';
+  const handleMouseLeave = () => {
+    setHovered(false);
   };
 
   const handleContinueClick = () => {
@@ -79,7 +79,7 @@ export const ContinueButton: React.FC<ContinueButtonProps> = ({ onContinueCallba
   return (
     <button
       onClick={handleContinueClick}
-      style={footerStyles.continueButton}
+      style={getContinueButtonStyle(hovered)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >

--- a/src/ui/upgrade/Footer/footerStyles.ts
+++ b/src/ui/upgrade/Footer/footerStyles.ts
@@ -11,7 +11,7 @@ export const footerStyles = {
     padding: 12
   } as CSSProperties,
 
-  continueButton: {
+  continueButtonBase: {
     padding: '14px 32px',
     fontSize: 18,
     borderRadius: 12,
@@ -20,9 +20,16 @@ export const footerStyles = {
     border: 'none',
     cursor: 'pointer',
     fontWeight: 'bold',
-    boxShadow: '0 6px 18px rgba(74, 222, 128, 0.4)',
     transition: 'all 0.3s ease',
     minWidth: 180,
     textShadow: '0 1px 2px rgba(0,0,0,0.3)',
   } as CSSProperties,
-}; 
+};
+
+export const getContinueButtonStyle = (hovered: boolean): CSSProperties => ({
+  ...footerStyles.continueButtonBase,
+  transform: hovered ? 'translateY(-2px)' : 'translateY(0)',
+  boxShadow: hovered
+    ? '0 8px 24px rgba(74, 222, 128, 0.6)'
+    : '0 6px 18px rgba(74, 222, 128, 0.4)',
+});

--- a/src/ui/upgrade/UpgradeTabNavigation.tsx
+++ b/src/ui/upgrade/UpgradeTabNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { TabType, TabConfig } from './types';
 import { tabStyles, getTabButtonStyle, getPriorityBadgeStyle } from './tabStyles';
 
@@ -41,12 +41,14 @@ export const UpgradeTabNavigation: React.FC<UpgradeTabNavigationProps> = ({
     onTabChange(tab);
   }, [onTabChange]);
 
-  const handleMouseEnter = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.currentTarget.style.transform = 'translateY(-2px)';
+  const [hoveredTab, setHoveredTab] = useState<TabType | null>(null);
+
+  const handleMouseEnter = (tabId: TabType) => {
+    setHoveredTab(tabId);
   };
 
-  const handleMouseLeave = (e: React.MouseEvent<HTMLButtonElement>, isActive: boolean) => {
-    e.currentTarget.style.transform = isActive ? 'translateY(-1px)' : 'translateY(0)';
+  const handleMouseLeave = () => {
+    setHoveredTab(null);
   };
 
   return (
@@ -59,9 +61,9 @@ export const UpgradeTabNavigation: React.FC<UpgradeTabNavigationProps> = ({
           <button
             key={tab.id}
             onClick={() => handleTabChange(tab.id)}
-            style={getTabButtonStyle(isActive, tab.color, isDiceTab)}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={(e) => handleMouseLeave(e, isActive)}
+            style={getTabButtonStyle(isActive, tab.color, isDiceTab, hoveredTab === tab.id)}
+            onMouseEnter={() => handleMouseEnter(tab.id)}
+            onMouseLeave={handleMouseLeave}
           >
             {/* Priority Badge */}
             {tab.priority && (

--- a/src/ui/upgrade/tabStyles.ts
+++ b/src/ui/upgrade/tabStyles.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react';
+import { sanitizeColor } from '../../utils/styleUtils';
 
 export const tabStyles = {
   tabNavigation: {
@@ -25,26 +26,31 @@ export const tabStyles = {
 };
 
 export const getTabButtonStyle = (
-  isActive: boolean, 
-  color: string, 
-  isDiceTab: boolean = false
-): CSSProperties => ({
-  padding: isDiceTab ? '14px 16px' : '12px 14px',
-  borderRadius: 10,
-  border: `2px solid ${isActive ? color : 'rgba(255,255,255,0.1)'}`,
-  background: isActive 
-    ? `linear-gradient(135deg, ${color}40, ${color}20)` 
-    : 'rgba(0,0,0,0.3)',
-  color: isActive ? color : '#ccc',
-  cursor: 'pointer',
-  fontSize: isDiceTab ? 14 : 13,
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  textAlign: 'center',
-  position: 'relative',
-  transform: isActive ? 'translateY(-1px)' : 'none',
-  boxShadow: isActive ? `0 4px 16px ${color}40` : 'none',
-});
+  isActive: boolean,
+  color: string,
+  isDiceTab: boolean = false,
+  isHovered: boolean = false
+): CSSProperties => {
+  const safeColor = sanitizeColor(color, '#ffffff');
+  const activeOrHover = isActive || isHovered;
+  return {
+    padding: isDiceTab ? '14px 16px' : '12px 14px',
+    borderRadius: 10,
+    border: `2px solid ${isActive ? safeColor : 'rgba(255,255,255,0.1)'}`,
+    background: isActive
+      ? `linear-gradient(135deg, ${safeColor}40, ${safeColor}20)`
+      : 'rgba(0,0,0,0.3)',
+    color: isActive ? safeColor : '#ccc',
+    cursor: 'pointer',
+    fontSize: isDiceTab ? 14 : 13,
+    fontWeight: 'bold',
+    transition: 'all 0.3s ease',
+    textAlign: 'center',
+    position: 'relative',
+    transform: activeOrHover ? 'translateY(-1px)' : 'none',
+    boxShadow: activeOrHover ? `0 4px 16px ${safeColor}40` : 'none',
+  };
+};
 
 export const getPriorityBadgeStyle = (): CSSProperties => ({
   position: 'absolute',

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -1,0 +1,4 @@
+export const sanitizeColor = (value: string, fallback = '#000000'): string => {
+  const trimmed = value.trim();
+  return /^#[0-9A-Fa-f]{3,8}$/.test(trimmed) ? trimmed : fallback;
+};


### PR DESCRIPTION
## Summary
- sanitize css colors
- refactor tab navigation hover styles without direct DOM manipulation
- refactor continue button hover handling

## Testing
- `npm run pre-commit` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6865a258ad80832cb21162384be4fb28