### PR TITLE
Add tower upgrade shake-drop effect

### DIFF
--- a/src/ui/TowerSpot/TowerSpot.tsx
+++ b/src/ui/TowerSpot/TowerSpot.tsx
@@ -156,9 +156,9 @@ export const TowerSpot: React.FC<TowerSpotProps> = ({
           <WallRenderer slot={slot} wallLevel={wallLevel} />
           
           {/* Tower with enhanced drag & touch support */}
-          <g 
-            className={showUpgrade ? 'tower-upgrade-anim' : ''}
-            style={{ 
+          <g
+            className={showUpgrade ? 'tower-upgrade-fall-anim' : ''}
+            style={{
               cursor: 'grab',
               opacity: draggedTowerSlotIdx === slotIdx ? 0.5 : 1,
               filter: draggedTowerSlotIdx === slotIdx ? 'brightness(0.7)' : 'none',

--- a/src/ui/TowerSpot/styles/animations.css
+++ b/src/ui/TowerSpot/styles/animations.css
@@ -327,4 +327,17 @@
   60% { transform: translateX(0) scale(1.12) translateY(-6px); }
   80% { transform: translateX(0) scale(1.04) translateY(-2px); }
   100% { transform: translateX(0) scale(1) translateY(0); }
-} 
+}
+
+.tower-upgrade-fall-anim {
+  animation: tower-upgrade-shake-drop 0.9s cubic-bezier(0.4,0.2,0.2,1);
+}
+@keyframes tower-upgrade-shake-drop {
+  0% { transform: translateX(0) translateY(-16px) scale(1); }
+  15% { transform: translateX(-6px) translateY(-16px) scale(1); }
+  30% { transform: translateX(6px) translateY(-16px) scale(1); }
+  45% { transform: translateX(-6px) translateY(-16px) scale(1); }
+  60% { transform: translateX(6px) translateY(-16px) scale(1); }
+  80% { transform: translateX(0) translateY(0) scale(1.05); }
+  100% { transform: translateX(0) translateY(0) scale(1); }
+}


### PR DESCRIPTION
## Summary
- introduce new `tower-upgrade-fall-anim` CSS animation for upgrades
- trigger new animation when a tower is upgraded

## Testing
- `npm run type-check`
- `npm run lint:check` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6866362f0a48832ca97619551a2799ab