### PR TITLE
Refactor store actions into slices

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,8 +17,17 @@ echo "🔍 Linting..."
 npm run lint:check
 LINT_EXIT_CODE=$?
 
+
 if [ $LINT_EXIT_CODE -ne 0 ]; then
   echo "❌ Linting failed with errors! Commit blocked."
+  exit 1
+fi
+
+# Prevent overly large commits
+ADDED_DELETED=$(git diff --cached --numstat | awk '{add+=$1; del+=$2} END {print add+del}')
+MAX_CHANGES=500
+if [ "$ADDED_DELETED" -gt "$MAX_CHANGES" ]; then
+  echo "❌ Commit exceeds $MAX_CHANGES changed lines ($ADDED_DELETED). Split your work."
   exit 1
 fi
 

--- a/src/models/store/slices/enemySlice.ts
+++ b/src/models/store/slices/enemySlice.ts
@@ -1,0 +1,130 @@
+export interface EnemySlice {
+  addEnemy: (enemy: import('../../gameTypes').Enemy) => void;
+  removeEnemy: (enemyId: string) => void;
+  damageEnemy: (enemyId: string, dmg: number) => void;
+  addBullet: (bullet: import('../../gameTypes').Bullet) => void;
+  removeBullet: (bulletId: string) => void;
+  addEffect: (effect: import('../../gameTypes').Effect) => void;
+  removeEffect: (effectId: string) => void;
+}
+
+export const createEnemySlice = (set: any, get: any): EnemySlice => ({
+  addEnemy: (enemy) => set((state: any) => ({
+    enemies: [...state.enemies, enemy]
+  })),
+
+  addBullet: (bullet) => set((state: any) => ({
+    bullets: [...state.bullets, bullet]
+  })),
+
+  removeBullet: (bulletId) => set((state: any) => ({
+    bullets: state.bullets.filter((b: any) => b.id !== bulletId)
+  })),
+
+  addEffect: (effect) => set((state: any) => ({
+    effects: [...state.effects, effect]
+  })),
+
+  removeEffect: (effectId) => set((state: any) => ({
+    effects: state.effects.filter((e: any) => e.id !== effectId)
+  })),
+
+  removeEnemy: (enemyId) => set((state: any) => {
+    const enemy = state.enemies.find((e: any) => e.id === enemyId);
+    if (!enemy) return {};
+
+    if (enemy.bossType) {
+      setTimeout(() => {
+        import('../../../game-systems/enemy/BossManager').then(({ default: BossManager }) => {
+          BossManager.handleBossDefeat(enemy);
+        });
+      }, 0);
+    }
+
+    const newKillCount = state.enemiesKilled + 1;
+
+    if (state.currentWave === 1) {
+      console.log(`\uD83D\uDC80 Enemy killed! Wave ${state.currentWave}: ${newKillCount}/${state.enemiesRequired} (${enemy.type}, special: ${enemy.isSpecial})`);
+    }
+
+    setTimeout(() => {
+      import('../../../game-systems/LootManager').then(({ default: LootManager }) => {
+        LootManager.handleEnemyDeath(enemy);
+      });
+    }, 0);
+
+    setTimeout(() => get().onEnemyKilled(enemy.isSpecial, enemy.type), 0);
+
+    setTimeout(() => {
+      import('../../../utils/sound').then(({ playContextualSound }) => {
+        playContextualSound('death');
+      });
+    }, 50);
+
+    return {
+      enemies: state.enemies.filter((e: any) => e.id !== enemyId),
+      gold: state.gold + enemy.goldValue,
+      enemiesKilled: newKillCount,
+      totalEnemiesKilled: state.totalEnemiesKilled + 1,
+    };
+  }),
+
+  damageEnemy: (enemyId, dmg) => {
+    const { towerSlots } = get();
+    const enemyObj = get().enemies.find((e: any) => e.id === enemyId);
+    set((state: any) => {
+      const enemy = state.enemies.find((e: any) => e.id === enemyId);
+      if (!enemy) return {};
+      const newHealth = enemy.health - dmg;
+      if (newHealth <= 0) {
+        if (enemy.bossType) {
+          setTimeout(() => {
+            import('../../../game-systems/enemy/BossManager').then(({ default: BossManager }) => {
+              BossManager.handleBossDefeat(enemy);
+            });
+          }, 0);
+        }
+
+        const newKillCount = state.enemiesKilled + 1;
+
+        if (state.currentWave === 1) {
+          console.log(`\uD83D\uDC80 Enemy killed! Wave ${state.currentWave}: ${newKillCount}/${state.enemiesRequired} (${enemy.type}, special: ${enemy.isSpecial})`);
+        }
+
+        setTimeout(() => {
+          import('../../../game-systems/LootManager').then(({ default: LootManager }) => {
+            LootManager.handleEnemyDeath(enemy);
+          });
+        }, 0);
+
+        setTimeout(() => get().onEnemyKilled(enemy.isSpecial, enemy.type), 0);
+
+        setTimeout(() => {
+          import('../../../utils/sound').then(({ playContextualSound }) => {
+            playContextualSound('death');
+          });
+        }, 50);
+
+        return {
+          enemies: state.enemies.filter((e: any) => e.id !== enemyId),
+          gold: state.gold + enemy.goldValue,
+          enemiesKilled: newKillCount,
+          totalEnemiesKilled: state.totalEnemiesKilled + 1,
+        };
+      }
+      return {
+        enemies: state.enemies.map((e: any) => e.id === enemyId ? { ...e, health: newHealth } : e),
+      };
+    });
+    if (enemyObj && enemyObj.health - dmg <= 0 && enemyObj.behaviorTag === 'tank') {
+      towerSlots.forEach((s: any, idx: number) => {
+        if (!s.tower) return;
+        const dx = s.x - enemyObj.position.x;
+        const dy = s.y - enemyObj.position.y;
+        if (Math.hypot(dx, dy) <= (import('../../utils/constants').GAME_CONSTANTS.TANK_DEATH_RADIUS)) {
+          get().damageTower(idx, enemyObj.damage);
+        }
+      });
+    }
+  },
+});

--- a/src/models/store/slices/towerSlice.ts
+++ b/src/models/store/slices/towerSlice.ts
@@ -1,0 +1,126 @@
+import { GAME_CONSTANTS } from '../../../utils/constants';
+import type { TowerSlot } from '../../gameTypes';
+
+export interface TowerSlice {
+  damageTower: (slotIdx: number, dmg: number) => void;
+  removeTower: (slotIdx: number) => void;
+  dismantleTower: (slotIdx: number) => void;
+  moveTower: (fromIdx: number, toIdx: number) => void;
+  buyWall: (slotIdx: number) => void;
+  hitWall: (slotIdx: number) => void;
+  purchaseShield: (idx: number, free?: boolean) => void;
+}
+
+export const createTowerSlice = (set: any, get: any): TowerSlice => ({
+  damageTower: (slotIdx, dmg) => set((state: any) => {
+    const slot = state.towerSlots[slotIdx] as TowerSlot;
+    if (!slot.tower) return {};
+
+    if (slot.tower.wallStrength > 0) {
+      const newWallStrength = Math.max(0, slot.tower.wallStrength - dmg);
+      const newSlots = [...state.towerSlots];
+      newSlots[slotIdx] = { ...slot, tower: { ...slot.tower, wallStrength: newWallStrength } };
+      return { towerSlots: newSlots };
+    }
+
+    const newHealth = slot.tower.health - dmg;
+    if (newHealth <= 0) {
+      const newSlots = [...state.towerSlots];
+      newSlots[slotIdx] = { ...slot, tower: null, wasDestroyed: true };
+      const newTowers = state.towers.filter((t: any) => t.id !== slot.tower!.id);
+
+      const shouldGameOver = newTowers.length === 0 && state.isStarted && !state.isGameOver;
+
+      if (shouldGameOver) {
+        console.log('\uD83D\uDC80 Game Over: All towers destroyed!');
+        import('../../../game-systems/EnemySpawner').then(({ stopEnemyWave }) => {
+          stopEnemyWave();
+        });
+        setTimeout(() => {
+          import('../../../utils/sound').then(({ playContextualSound }) => {
+            playContextualSound('defeat');
+          });
+        }, 100);
+      }
+
+      return {
+        towerSlots: newSlots,
+        towers: newTowers,
+        lostTowerThisWave: true,
+        isGameOver: shouldGameOver,
+      };
+    }
+
+    const newSlots = [...state.towerSlots];
+    newSlots[slotIdx] = { ...slot, tower: { ...slot.tower, health: newHealth } };
+    return { towerSlots: newSlots };
+  }),
+
+  removeTower: (slotIdx) => set((state: any) => {
+    const slot = state.towerSlots[slotIdx];
+    if (!slot.tower) return {};
+    const newSlots = [...state.towerSlots];
+    newSlots[slotIdx] = { ...slot, tower: null };
+    return {
+      towerSlots: newSlots,
+      towers: state.towers.filter((t: any) => t.id !== slot.tower!.id),
+    };
+  }),
+
+  dismantleTower: (slotIdx) => set((state: any) => {
+    const slot = state.towerSlots[slotIdx];
+    if (!slot.tower) return {};
+    const refund = Math.floor(GAME_CONSTANTS.TOWER_COST * 0.7);
+    const newSlots = [...state.towerSlots];
+    newSlots[slotIdx] = { ...slot, tower: null };
+    return {
+      towerSlots: newSlots,
+      towers: state.towers.filter((t: any) => t.id !== slot.tower!.id),
+      gold: state.gold + refund,
+    };
+  }),
+
+  moveTower: (fromIdx, toIdx) => set((state: any) => {
+    const fromSlot = state.towerSlots[fromIdx];
+    const toSlot = state.towerSlots[toIdx];
+    if (!fromSlot.tower || toSlot.tower || !toSlot.unlocked) return {};
+    const newSlots = [...state.towerSlots];
+    newSlots[toIdx] = { ...toSlot, tower: fromSlot.tower };
+    newSlots[fromIdx] = { ...fromSlot, tower: null };
+    return { towerSlots: newSlots };
+  }),
+
+  buyWall: (slotIdx) => set((state: any) => {
+    const cost = GAME_CONSTANTS.WALL_COST;
+    if (state.gold < cost) return {};
+    const slot = state.towerSlots[slotIdx];
+    if (!slot.tower) return {};
+    const newSlots = [...state.towerSlots];
+    newSlots[slotIdx] = { ...slot, tower: { ...slot.tower, wallStrength: 10 } };
+    return {
+      towerSlots: newSlots,
+      gold: state.gold - cost,
+      totalGoldSpent: state.totalGoldSpent + cost,
+    };
+  }),
+
+  hitWall: (slotIdx) => set((state: any) => {
+    const slot = state.towerSlots[slotIdx];
+    if (!slot.tower || slot.tower.wallStrength <= 0) return {};
+    const newSlots = [...state.towerSlots];
+    newSlots[slotIdx] = { ...slot, tower: { ...slot.tower, wallStrength: slot.tower.wallStrength - 1 } };
+    return { towerSlots: newSlots };
+  }),
+
+  purchaseShield: (idx, free) => set((state: any) => {
+    const shield = GAME_CONSTANTS.WALL_SHIELDS[idx];
+    if (!shield) return {};
+    const cost = free ? 0 : shield.cost;
+    if (state.gold < cost) return {};
+    return {
+      gold: state.gold - cost,
+      shieldUpgradesPurchased: state.shieldUpgradesPurchased + 1,
+      totalGoldSpent: state.totalGoldSpent + cost,
+    };
+  }),
+});


### PR DESCRIPTION
## Summary
- refactor `src/models/store/index.ts` to delegate tower and enemy logic to new Zustand slices
- add `src/models/store/slices/enemySlice.ts` and `towerSlice.ts`
- extend pre-commit hook to block commits with more than 500 changed lines

## Testing
- `npm run lint:check` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_686a2d2f8f88832cbb82e2aaf7dfa3c7