### PR TITLE
Show map background on all screens

### DIFF
--- a/src/game-systems/GameLoop.ts
+++ b/src/game-systems/GameLoop.ts
@@ -21,7 +21,7 @@ let gameLoopMetrics: GameLoopMetrics = {
   avgDelta: 16
 };
 
-export function startGameLoop() {
+export function startGameLoop(existingManager?: EnvironmentManager) {
   let frameId = 0;
   let lastUpdateTime = performance.now();
   const lastStateSnapshot = {
@@ -32,7 +32,7 @@ export function startGameLoop() {
   };
   
   // Initialize environment manager
-  const environmentManager = new EnvironmentManager();
+  const environmentManager = existingManager ?? new EnvironmentManager();
 
   const loop = (currentTime: number) => {
     const deltaTime = currentTime - lastUpdateTime;

--- a/src/ui/GameBoard/hooks/useGameLoop.ts
+++ b/src/ui/GameBoard/hooks/useGameLoop.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { stopEnemyWave, startContinuousSpawning, stopContinuousSpawning } from '../../../game-systems/EnemySpawner';
 import { startGameLoop } from '../../../game-systems/GameLoop';
+import type { EnvironmentManager } from '../../../game-systems/environment/EnvironmentManager';
 import { waveManager } from '../../../game-systems/WaveManager';
 // import { startBackgroundMusic } from '../../../utils/sound'; // 🎵 OYUN MÜZİĞİ DEVRE DIŞI
 
@@ -8,7 +9,8 @@ export const useGameLoop = (
   isStarted: boolean,
   isRefreshing: boolean,
   isPreparing: boolean,
-  currentWave: number
+  currentWave: number,
+  environmentManager: EnvironmentManager | null
 ) => {
   const loopStopper = useRef<(() => void) | null>(null);
 
@@ -22,7 +24,7 @@ export const useGameLoop = (
     }
     
     if (!loopStopper.current) {
-      loopStopper.current = startGameLoop();
+      loopStopper.current = startGameLoop(environmentManager ?? undefined);
       // startBackgroundMusic(); // 🎵 OYUN MÜZİĞİ DEVRE DIŞI
     }
     
@@ -36,5 +38,5 @@ export const useGameLoop = (
       loopStopper.current?.();
       loopStopper.current = null;
     };
-  }, [isStarted, isRefreshing, isPreparing, currentWave]);
+  }, [isStarted, isRefreshing, isPreparing, currentWave, environmentManager]);
 }; 


### PR DESCRIPTION
## Summary
- initialize `EnvironmentManager` in `GameBoard` so the map is rendered immediately
- allow `startGameLoop` to accept an existing `EnvironmentManager`
- pass the manager through `useGameLoop`

## Testing
- `npm run lint:check` *(fails: cannot find packages)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686bb5a705b8832ca949753b34e9bd6a