### PR TITLE
Implement automatic weather effect activation

### DIFF
--- a/src/game-systems/market/WeatherEffectMarket.ts
+++ b/src/game-systems/market/WeatherEffectMarket.ts
@@ -506,22 +506,23 @@ export class WeatherEffectMarket {
    * Automatically activate all owned effects at wave start
    */
   autoActivateEffects(currentWave: number): void {
-    for (const cardId of this.ownedCards) {
-      const lastWave = this.lastActivatedWave.get(cardId);
-      if (lastWave === currentWave) continue;
+    const cardsToActivate = WEATHER_EFFECT_CARDS.filter(c =>
+      this.ownedCards.has(c.id) && this.lastActivatedWave.get(c.id) !== currentWave
+    );
 
-      const card = WEATHER_EFFECT_CARDS.find(c => c.id === cardId);
-      if (!card) continue;
-
-      toast.info(`${card.name} hava yükseltmesi başlatılıyor.`);
-      toast.info(`${card.name} hava yükseltmesi devreye alındı.`);
-      if (this.activateEffect(cardId)) {
-        toast.info(`${card.name} hava yükseltmesi uygulanıyor.`);
-        this.lastActivatedWave.set(cardId, currentWave);
-        setTimeout(() => {
-          toast.info(`${card.name} hava yükseltmesi süresi doldu.`);
-        }, card.duration);
-      }
+    let delay = 0;
+    for (const card of cardsToActivate) {
+      setTimeout(() => {
+        toast.info(`${card.name} hava yükseltmesi devreye alındı.`);
+        if (this.activateEffect(card.id)) {
+          toast.info(`${card.name} hava yükseltmesi uygulanıyor.`);
+          this.lastActivatedWave.set(card.id, currentWave);
+          setTimeout(() => {
+            toast.info(`${card.name} hava yükseltmesi süresi doldu.`);
+          }, card.duration);
+        }
+      }, delay);
+      delay += card.duration + 1000; // küçük boşlukla sırayla başlat
     }
   }
 

--- a/src/game-systems/missions/MissionRewardManager.ts
+++ b/src/game-systems/missions/MissionRewardManager.ts
@@ -57,6 +57,19 @@ export class MissionRewardManager {
         }
         break;
       }
+
+      case 'upgrade': {
+        if (mission.reward.special === 'bullet') {
+          const { upgradeBullet } = require('../../models/store').useGameStore.getState();
+          upgradeBullet(true);
+        } else if (mission.reward.special === 'shield') {
+          const { upgradeWall } = require('../../models/store').useGameStore.getState();
+          upgradeWall();
+        }
+        const { completeMission } = require('../../models/store').useGameStore.getState();
+        completeMission(mission.id);
+        break;
+      }
     }
 
     return updates;

--- a/src/game-systems/missions/MissionTemplateManager.ts
+++ b/src/game-systems/missions/MissionTemplateManager.ts
@@ -112,6 +112,23 @@ export class MissionTemplateManager {
           }
         },
         {
+          name: 'Ateş Gücü Denemesi',
+          description: '20 düşman öldür ve Ateş Gücü 3 seviyesine ulaş',
+          category: 'combat' as const,
+          objective: {
+            type: 'kill_enemies' as const,
+            target: 20,
+            description: 'Görevsel eliminasyon',
+            trackingKey: 'totalEnemiesKilled'
+          },
+          reward: {
+            type: 'upgrade' as const,
+            amount: 1,
+            description: 'Ateş Gücü Seviye 4',
+            special: 'bullet'
+          }
+        },
+        {
           name: 'Dayanıklılık Testi',
           description: '15 wave tamamla',
           category: 'survival' as const,

--- a/src/models/gameTypes.ts
+++ b/src/models/gameTypes.ts
@@ -413,6 +413,7 @@ export interface GameState {
   // Daily Missions System
   dailyMissions: DailyMission[];
   lastMissionRefresh: number;
+  completedMissions: string[];
   unlockedTowerTypes: string[];
 }
 
@@ -553,7 +554,7 @@ export interface MissionObjective {
 }
 
 export interface MissionReward {
-  type: 'gold' | 'energy' | 'actions' | 'experience' | 'unlock';
+  type: 'gold' | 'energy' | 'actions' | 'experience' | 'unlock' | 'upgrade';
   amount: number;
   description: string;
   special?: string; // Special rewards like unlocks

--- a/src/models/store/index.ts
+++ b/src/models/store/index.ts
@@ -14,6 +14,7 @@ import { createEnergySlice, type EnergySlice, addEnemyKillListener, removeEnemyK
 import { createEconomySlice, type EconomySlice } from './slices/economySlice';
 import { createUpgradeSlice, type UpgradeSlice } from './slices/upgradeSlice';
 import { createEnvironmentSlice, type EnvironmentSlice } from './slices/environmentSlice';
+import { createMissionSlice, type MissionSlice } from './slices/missionSlice';
 
 export type Store = GameState &
   DiceSlice &
@@ -24,7 +25,8 @@ export type Store = GameState &
   TowerSlice &
   EconomySlice &
   UpgradeSlice &
-  EnvironmentSlice & {
+  EnvironmentSlice &
+  MissionSlice & {
     resetGame: () => void;
     setStarted: (started: boolean) => void;
     setRefreshing: (refreshing: boolean) => void;
@@ -41,6 +43,7 @@ export const useGameStore = create<Store>((set, get, api): Store => ({
   ...createEconomySlice(set, get, api),
   ...createUpgradeSlice(set, get, api),
   ...createEnvironmentSlice(set, get, api),
+  ...createMissionSlice(set, get, api),
 
   resetGame: () => set(() => ({ ...initialState, gameStartTime: Date.now() })),
 

--- a/src/models/store/initialState.ts
+++ b/src/models/store/initialState.ts
@@ -130,6 +130,7 @@ export const initialState: GameState = {
   gameStartTime: Date.now(),
   dailyMissions: [],
   lastMissionRefresh: 0,
+  completedMissions: [],
   unlockedTowerTypes: [],
 
   // ✅ NEW: Environment & Terrain System for Issue #62

--- a/src/models/store/slices/missionSlice.ts
+++ b/src/models/store/slices/missionSlice.ts
@@ -1,0 +1,17 @@
+import type { StateCreator } from 'zustand';
+import type { Store } from '../index';
+
+export interface MissionSlice {
+  completeMission: (missionId: string) => void;
+  isMissionCompleted: (missionId: string) => boolean;
+}
+
+export const createMissionSlice: StateCreator<Store, [], [], MissionSlice> = (set, get) => ({
+  completeMission: (missionId) => set((state: Store) => {
+    if (state.completedMissions.includes(missionId)) return {};
+    return { completedMissions: [...state.completedMissions, missionId] };
+  }),
+  isMissionCompleted: (missionId) => {
+    return get().completedMissions.includes(missionId);
+  }
+});

--- a/src/models/store/slices/waveSlice.ts
+++ b/src/models/store/slices/waveSlice.ts
@@ -60,6 +60,9 @@ export const createWaveSlice: StateCreator<Store, [], [], WaveSlice> = (set, _ge
       import('../../../game-systems/EnemySpawner').then(({ startEnemyWave }) => {
         startEnemyWave(state.currentWave);
       });
+      import('../../../game-systems/market/WeatherEffectMarket').then(({ weatherEffectMarket }) => {
+        weatherEffectMarket.autoActivateEffects(state.currentWave);
+      });
     }, 100);
     return {
       isPreparing: false,

--- a/src/ui/game/market/WeatherMarketContent.tsx
+++ b/src/ui/game/market/WeatherMarketContent.tsx
@@ -42,15 +42,6 @@ export const WeatherMarketContent: React.FC = () => {
     }
   };
 
-  const handleActivateEffect = (cardId: string) => {
-    const success = weatherEffectMarket.activateEffect(cardId);
-    if (success) {
-      setActiveEffects(weatherEffectMarket.getActiveEffects());
-      playSound('energy-recharge');
-    } else {
-      playSound('error');
-    }
-  };
 
   const formatTime = (ms: number): string => {
     const seconds = Math.floor(ms / 1000);
@@ -165,7 +156,6 @@ export const WeatherMarketContent: React.FC = () => {
                 key={card.id}
                 card={card}
                 gold={gold}
-                onActivate={() => handleActivateEffect(card.id)}
                 mode="activate"
                 isActive={activeEffects.some(effect => effect.card.id === card.id)}
               />
@@ -189,7 +179,6 @@ interface WeatherEffectCardProps {
   card: WeatherEffectCard;
   gold: number;
   onPurchase?: () => void;
-  onActivate?: () => void;
   mode: 'purchase' | 'activate';
   isActive?: boolean;
 }
@@ -198,7 +187,6 @@ const WeatherEffectCard: React.FC<WeatherEffectCardProps> = ({
   card,
   gold,
   onPurchase,
-  onActivate,
   mode,
   isActive = false
 }) => {
@@ -285,28 +273,42 @@ const WeatherEffectCard: React.FC<WeatherEffectCardProps> = ({
         </div>
       </div>
 
-      {/* Action Button */}
-      <button
-        onClick={mode === 'purchase' ? onPurchase : onActivate}
-        disabled={!isAvailable}
-        style={{
-          width: '100%',
-          padding: '10px',
-          backgroundColor: isAvailable ? (mode === 'purchase' ? '#10B981' : '#3B82F6') : '#4A5568',
-          color: '#FFF',
-          border: 'none',
-          borderRadius: '6px',
-          cursor: isAvailable ? 'pointer' : 'not-allowed',
-          fontSize: '14px',
-          fontWeight: 'bold',
-          transition: 'background-color 0.2s'
-        }}
-      >
-        {mode === 'purchase' 
-          ? (canAfford ? '💰 Satın Al' : '💸 Yetersiz Altın')
-          : (isActive ? '⏳ Aktif' : '⚡ Aktifleştir')
-        }
-      </button>
+      {/* Action Button or Info */}
+      {mode === 'purchase' ? (
+        <button
+          onClick={onPurchase}
+          disabled={!isAvailable}
+          style={{
+            width: '100%',
+            padding: '10px',
+            backgroundColor: isAvailable ? '#10B981' : '#4A5568',
+            color: '#FFF',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: isAvailable ? 'pointer' : 'not-allowed',
+            fontSize: '14px',
+            fontWeight: 'bold',
+            transition: 'background-color 0.2s'
+          }}
+        >
+          {canAfford ? '💰 Satın Al' : '💸 Yetersiz Altın'}
+        </button>
+      ) : (
+        <div
+          style={{
+            width: '100%',
+            padding: '10px',
+            backgroundColor: '#4A5568',
+            color: '#FFF',
+            borderRadius: '6px',
+            textAlign: 'center',
+            fontSize: '13px',
+            fontWeight: 'bold'
+          }}
+        >
+          {isActive ? '✅ Bu dalgada aktif' : '🌊 Dalga başlayınca otomatik etkinleşir'}
+        </div>
+      )}
     </div>
   );
 }; 

--- a/src/ui/game/market/WeatherMarketPanel.tsx
+++ b/src/ui/game/market/WeatherMarketPanel.tsx
@@ -49,15 +49,6 @@ export const WeatherMarketPanel: React.FC<WeatherMarketPanelProps> = ({ isOpen, 
     }
   };
 
-  const handleActivateEffect = (cardId: string) => {
-    const success = weatherEffectMarket.activateEffect(cardId);
-    if (success) {
-      setActiveEffects(weatherEffectMarket.getActiveEffects());
-      playSound('energy-recharge');
-    } else {
-      playSound('error');
-    }
-  };
 
   const formatTime = (ms: number): string => {
     const seconds = Math.floor(ms / 1000);
@@ -218,7 +209,6 @@ export const WeatherMarketPanel: React.FC<WeatherMarketPanelProps> = ({ isOpen, 
                   key={card.id}
                   card={card}
                   gold={gold}
-                  onActivate={() => handleActivateEffect(card.id)}
                   mode="activate"
                   isActive={activeEffects.some(effect => effect.card.id === card.id)}
                 />
@@ -385,25 +375,21 @@ const WeatherEffectCard: React.FC<WeatherEffectCardProps> = ({
         </button>
       )}
 
-      {mode === 'activate' && onActivate && (
-        <button
-          onClick={onActivate}
-          disabled={isActive}
+      {mode === 'activate' && (
+        <div
           style={{
             width: '100%',
             padding: '12px',
-            backgroundColor: isActive ? '#6B7280' : '#8B5CF6',
+            backgroundColor: '#4A5568',
             color: '#FFF',
-            border: 'none',
             borderRadius: '8px',
-            cursor: isActive ? 'not-allowed' : 'pointer',
-            fontSize: '16px',
-            fontWeight: 'bold',
-            transition: 'background-color 0.2s'
+            textAlign: 'center',
+            fontSize: '14px',
+            fontWeight: 'bold'
           }}
         >
-          {isActive ? '✅ Aktif' : '⚡ Etkinleştir'}
-        </button>
+          {isActive ? '✅ Bu dalgada aktif' : '🌊 Dalga başlayınca otomatik etkinleşir'}
+        </div>
       )}
     </div>
   );

--- a/src/ui/game/upgrades/FireUpgrades.tsx
+++ b/src/ui/game/upgrades/FireUpgrades.tsx
@@ -41,29 +41,33 @@ export const FireUpgrades: React.FC = () => {
         
         // DEBUG: Current state logging (removed from production)
         
-        const canUpgrade = isNextLevel && gold >= cost;
+        const missionReq = bulletType.missionRequirement;
+        const missionCompleted = missionReq ? useGameStore.getState().isMissionCompleted(missionReq.id) : true;
+        const canUpgrade = isNextLevel && gold >= cost && missionCompleted;
         const isMaxed = isPastLevel; // Geçmiş seviyeler "tamamlanmış" olarak gösterilir
         const isLocked = isFutureLevel; // Gelecek seviyeler kilitli
         
         // Bullet level progression logic verified
         
+        const requirementText = missionReq && !missionCompleted
+          ? `Bu yükseltmeyi kazanmak için:\nAteş Gücü ${missionReq.id === 'fire_mastery' ? 3 : ''} seviyesi ve görev: ${missionReq.text}`
+          : `${bulletType.name} mermi sistemi. Daha güçlü ve etkili saldırılar.`;
+
         const upgradeData = {
           name: bulletType.name,
-          description: isLocked 
-            ? `🔒 Önce Level ${currentBulletLevel + 1} alın` 
-            : isPastLevel 
+          description: isLocked
+            ? `🔒 Önce Level ${currentBulletLevel + 1} alın`
+            : isPastLevel
               ? `✅ Tamamlandı - Aktif seviye`
-              : `${bulletType.name} mermi sistemi. Daha güçlü ve etkili saldırılar.`,
+              : requirementText,
           currentLevel: isPastLevel ? 1 : isCurrentLevel ? 1 : 0, // Visual için
           baseCost: cost,
           maxLevel: 1,
           onUpgrade: () => {
-            if (!isNextLevel) {
-              // Cannot upgrade: not next level
+            if (!isNextLevel || (missionReq && !missionCompleted)) {
               return;
             }
-            
-            // CRITICAL FIX: Use normal bullet upgrade with clean cost already calculated
+
             upgradeBullet(false);
           },
           icon: isPastLevel ? "✅" : isCurrentLevel ? "🔥" : isLocked ? "🔒" : "🔥",
@@ -72,11 +76,13 @@ export const FireUpgrades: React.FC = () => {
             : isLocked 
               ? '#666666' // Gri - kilitli
               : getUpgradeColor(false, canUpgrade, isMaxed),
-          additionalInfo: isPastLevel 
+          additionalInfo: isPastLevel
             ? `✅ Aktif - Hasar: x${bulletType.damageMultiplier}`
-            : isLocked 
+            : isLocked
               ? `🔒 Level ${currentBulletLevel + 1} gerekli`
-              : `Hasar Çarpanı: x${bulletType.damageMultiplier} | Hız: x${bulletType.speedMultiplier || 1}`
+              : missionReq && !missionCompleted
+                ? requirementText
+                : `Hasar Çarpanı: x${bulletType.damageMultiplier} | Hız: x${bulletType.speedMultiplier || 1}`
         };
 
         return (

--- a/src/ui/game/upgrades/types.ts
+++ b/src/ui/game/upgrades/types.ts
@@ -47,6 +47,7 @@ export interface BulletTypeData {
   fireRateMultiplier: number;
   speedMultiplier: number;
   freezeDuration?: number;
+  missionRequirement?: { id: string; text: string };
 }
 
 // Package tracking types

--- a/src/utils/constants/gameConstants.ts
+++ b/src/utils/constants/gameConstants.ts
@@ -756,6 +756,10 @@ export const GAME_CONSTANTS = {
       damageMultiplier: 1.5,
       fireRateMultiplier: 0.8,
       speedMultiplier: 1.3,
+      missionRequirement: {
+        id: 'fire_mastery',
+        text: '20 düşman öldür (Günlük Görev)'
+      },
     },
     {
       name: 'Yakhar',

--- a/src/utils/sound/soundEffects.ts
+++ b/src/utils/sound/soundEffects.ts
@@ -1,6 +1,7 @@
 import { musicManager } from './musicManager';
 import { getSettings } from '../settings';
 import { GAME_CONSTANTS } from '../constants';
+import { useGameStore } from '../../models/store';
 
 
 export const audioCache: Record<string, HTMLAudioElement> = {};
@@ -84,6 +85,64 @@ const SOUND_COOLDOWN_DURATIONS: Record<string, number> = {
   'default': 200
 };
 
+// 🎮 Sound categories for better management
+const SOUND_CATEGORIES = {
+  // Game scene sounds - paused during upgrade
+  GAME_SCENE: [
+    'explosion-large',
+    'explosion-small',
+    'tower-attack-explosive',
+    'tower-attack-laser',
+    'tower-attack-plasma',
+    'tower-attack-sniper',
+    'tower-create-sound',
+    'tower-destroy',
+    'tower-levelup-sound',
+    'tower-repair',
+    'defeat-heavy',
+    'boss-bombing',
+    'boss-charge',
+    'boss-defeat',
+    'boss-entrance',
+    'boss-ground-slam',
+    'boss-missile',
+    'boss-phase-transition',
+    'boss-reality-tear',
+    'boss-spawn-minions',
+    'ambient-battle',
+    'ambient-wind',
+    'energy-recharge',
+    'freeze-effect',
+    'slow-effect',
+    'shield-activate',
+    'shield-break',
+    'gameover',
+    'wave-complete',
+    'victory-fanfare'
+  ],
+
+  // UI/Market sounds - continue during upgrade
+  UI_MARKET: [
+    'dice-roll',
+    'click',
+    'hover',
+    'lock-break',
+    'coin-collect',
+    'gold-drop',
+    'loot-common',
+    'loot-rare',
+    'loot-epic',
+    'loot-legendary',
+    'pickup-common',
+    'pickup-rare',
+    'notification',
+    'error',
+    'countdown-beep'
+  ]
+} as const;
+
+const isGameSceneSound = (sound: string) => SOUND_CATEGORIES.GAME_SCENE.includes(sound);
+
 /**
  * Ses için cooldown kontrolü yapar
  */
@@ -125,7 +184,10 @@ export function testVolumeControls(): void {
 
 export function playSound(sound: string): void {
   if (missingSounds.has(sound)) return;
-  
+
+  const { isRefreshing } = useGameStore.getState();
+  if (isRefreshing && isGameSceneSound(sound)) return;
+
   // 🔊 COOLDOWN CHECK: Ses çok sık çalınıyorsa engelle
   if (!canPlaySound(sound)) {
     if (GAME_CONSTANTS.DEBUG_MODE) {
@@ -237,62 +299,6 @@ export function clearSoundCache(): void {
   soundLastPlayed.clear();
   musicManager.stop();
 }
-
-// 🎮 Sound categories for better management
-const SOUND_CATEGORIES = {
-  // Game scene sounds - paused during upgrade
-  GAME_SCENE: [
-    'explosion-large',
-    'explosion-small', 
-    'tower-attack-explosive',
-    'tower-attack-laser',
-    'tower-attack-plasma',
-    'tower-attack-sniper',
-    'tower-create-sound',
-    'tower-destroy',
-    'tower-levelup-sound',
-    'tower-repair',
-    'defeat-heavy',
-    'boss-bombing',
-    'boss-charge',
-    'boss-defeat',
-    'boss-entrance',
-    'boss-ground-slam',
-    'boss-missile',
-    'boss-phase-transition',
-    'boss-reality-tear',
-    'boss-spawn-minions',
-    'ambient-battle',
-    'ambient-wind',
-    'energy-recharge',
-    'freeze-effect',
-    'slow-effect',
-    'shield-activate',
-    'shield-break',
-    'gameover',
-    'wave-complete',
-    'victory-fanfare'
-  ],
-  
-  // UI/Market sounds - continue during upgrade
-  UI_MARKET: [
-    'dice-roll',
-    'click',
-    'hover',
-    'lock-break',
-    'coin-collect',
-    'gold-drop',
-    'loot-common',
-    'loot-rare',
-    'loot-epic',
-    'loot-legendary',
-    'pickup-common',
-    'pickup-rare',
-    'notification',
-    'error',
-    'countdown-beep'
-  ]
-} as const;
 
 /**
  * 🎮 UPGRADE SCREEN: Stop only game scene sounds (keep UI/market sounds)


### PR DESCRIPTION
## Summary
- stop game-scene sounds while upgrade screen is open
- auto-activate owned weather effects each wave
- gate higher fire upgrades behind mission completion
- show auto-activation info instead of an activate button

## Testing
- `npm run lint:check` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_686fd9779cdc832c98991629e10d4d6e